### PR TITLE
fix: fix wrong url host parsing rule

### DIFF
--- a/forwarder.go
+++ b/forwarder.go
@@ -7,7 +7,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"strings"
+	"path"
 	"sync"
 	"syscall"
 
@@ -144,16 +144,24 @@ func forwarders(ctx context.Context, options []*Option, config *restclient.Confi
 
 // It is to forward port, and return the forwarder.
 func portForwardAPod(req *portForwardAPodRequest) (*portforward.PortForwarder, error) {
-	path := fmt.Sprintf("/api/v1/namespaces/%s/pods/%s/portforward",
-		req.Pod.Namespace, req.Pod.Name)
-	hostIP := strings.TrimLeft(req.RestConfig.Host, "htps:/")
+	targetURL, err := url.Parse(req.RestConfig.Host)
+	if err != nil {
+		return nil, err
+	}
+
+	targetURL.Path = path.Join(
+		"api", "v1",
+		"namespaces", req.Pod.Namespace,
+		"pods", req.Pod.Name,
+		"portforward",
+	)
 
 	transport, upgrader, err := spdy.RoundTripperFor(req.RestConfig)
 	if err != nil {
 		return nil, err
 	}
 
-	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, &url.URL{Scheme: "https", Path: path, Host: hostIP})
+	dialer := spdy.NewDialer(upgrader, &http.Client{Transport: transport}, http.MethodPost, targetURL)
 	fw, err := portforward.New(dialer, []string{fmt.Sprintf("%d:%d", req.LocalPort, req.PodPort)}, req.StopCh, req.ReadyCh, req.Streams.Out, req.Streams.ErrOut)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
In previous implementation, API server host starts with `https://p` will fail as the forward parses wrongly. This pull request fixed by using `net/url` to parse the api server url from rest config.