### PR TITLE
allow creation of forwarder with restclient.Config

### DIFF
--- a/forwarder.go
+++ b/forwarder.go
@@ -54,6 +54,11 @@ func WithForwarders(ctx context.Context, options []*Option, kubeconfigPath strin
 	return forwarders(ctx, options, config)
 }
 
+// It is to forward port with restclient.Config.
+func WithRestConfig(ctx context.Context, options []*Option, config *restclient.Config) (*Result, error) {
+	return forwarders(ctx, options, config)
+}
+
 // It is to forward port for k8s cloud services.
 func forwarders(ctx context.Context, options []*Option, config *restclient.Config) (*Result, error) {
 	newOptions, err := parseOptions(options)


### PR DESCRIPTION
Allow creation of a forwarder via a restclient.Config -- I already have one available (that isn't encoded as a file).