### PR TITLE
Use path builder for default kubeconfig path

### DIFF
--- a/forwarder.go
+++ b/forwarder.go
@@ -41,9 +41,12 @@ func WithForwardersEmbedConfig(ctx context.Context, options []*Option, kubeconfi
 }
 
 // It is to forward port for k8s cloud services.
+// If `kubeconfigPath` is empty, the default kubeconfig location is used (e.g. `~/.kube/config`)
 func WithForwarders(ctx context.Context, options []*Option, kubeconfigPath string) (*Result, error) {
 	if kubeconfigPath == "" {
-		kubeconfigPath = "~/.kube/config"
+		home, _ := os.UserHomeDir()
+
+		kubeconfigPath = path.Join(home, ".kube", "config")
 	}
 
 	config, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)


### PR DESCRIPTION
Closes Panic when using default kubeconfig path #7

This should also make it OS-agnostic and not fail on Windows.